### PR TITLE
Remove explicit layoutSubviews call

### DIFF
--- a/ColorMixer/ColorMixViewController.swift
+++ b/ColorMixer/ColorMixViewController.swift
@@ -183,7 +183,7 @@ class ColorMixViewController: UIViewController {
         updateSecondaryColor()
 
         gradientLayer.frame = gradientLayerView.frame
-        colorSectionBar.layoutSubviews()
+        colorSectionBar.layoutIfNeeded()
         updateMixedColor()
     }
 


### PR DESCRIPTION
As per the docs: https://developer.apple.com/documentation/uikit/uiview/1622482-layoutsubviews

> You should not call this method directly. If you want to force a layout update, call the setNeedsLayout() method instead to do so prior to the next drawing update. If you want to update the layout of your views immediately, call the layoutIfNeeded() method.