### PR TITLE
Pin pseduo loading view to top and bottom

### DIFF
--- a/ColorMixer/Base.lproj/Main.storyboard
+++ b/ColorMixer/Base.lproj/Main.storyboard
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -29,13 +26,13 @@
                                 <rect key="frame" x="316" y="60" width="51" height="31"/>
                             </switch>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Animate" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V6M-wm-72u">
-                                <rect key="frame" x="309.5" y="39" width="63" height="21"/>
+                                <rect key="frame" x="309" y="39" width="63" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="fill" contentVerticalAlignment="fill" text="#" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="24p-f6-2cT">
-                                <rect key="frame" x="42.5" y="87" width="196" height="50"/>
+                                <rect key="frame" x="42.5" y="86" width="196" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="196" id="GS8-oW-L82"/>
                                     <constraint firstAttribute="height" constant="50" id="KKs-OF-gnY"/>
@@ -48,7 +45,7 @@
                                 </connections>
                             </textField>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jOz-JS-QV8" customClass="TriangleView" customModule="ColorMixer" customModuleProvider="target">
-                                <rect key="frame" x="14" y="93.5" width="18.5" height="37.5"/>
+                                <rect key="frame" x="14" y="92.5" width="18.5" height="37.5"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <gestureRecognizers/>
                                 <constraints>
@@ -59,15 +56,15 @@
                                 </connections>
                             </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oW8-i2-EWF" customClass="TriangleView" customModule="ColorMixer" customModuleProvider="target">
-                                <rect key="frame" x="248.5" y="93.5" width="19" height="37.5"/>
+                                <rect key="frame" x="248.5" y="92.5" width="19" height="37.5"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <gestureRecognizers/>
                                 <connections>
                                     <outletCollection property="gestureRecognizers" destination="a4R-Ag-FAQ" appends="YES" id="Kja-2H-05g"/>
                                 </connections>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lLd-Ht-LjB">
-                                <rect key="frame" x="314" y="157" width="2" height="374"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lLd-Ht-LjB" userLabel="RightView">
+                                <rect key="frame" x="314" y="156" width="2" height="375"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="2" id="pFw-Dl-boh"/>
@@ -94,7 +91,7 @@
                                 </constraints>
                             </view>
                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="He5-0h-pwh">
-                                <rect key="frame" x="126" y="157" width="378" height="375"/>
+                                <rect key="frame" x="125.5" y="156" width="379" height="376"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="He5-0h-pwh" secondAttribute="height" multiplier="1:1" id="Gam-l4-UYm"/>
                                 </constraints>
@@ -174,7 +171,7 @@
                                         </constraints>
                                     </view>
                                     <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UUi-dS-WbW" customClass="TriangleView" customModule="ColorMixer" customModuleProvider="target">
-                                        <rect key="frame" x="174.5" y="-25" width="25" height="25"/>
+                                        <rect key="frame" x="175" y="-25" width="25" height="25"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="UUi-dS-WbW" secondAttribute="height" multiplier="1:1" id="3sh-UC-bT0"/>
@@ -222,43 +219,43 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qe9-EM-noj">
-                                <rect key="frame" x="47" y="157" width="187.5" height="187"/>
+                                <rect key="frame" x="47" y="156" width="187.5" height="187.5"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Qe9-EM-noj" secondAttribute="height" multiplier="1:1" id="9WH-55-nmD"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qNn-1P-VSK">
-                                <rect key="frame" x="47.5" y="344" width="187" height="187"/>
+                                <rect key="frame" x="47" y="343.5" width="187.5" height="187.5"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="qNn-1P-VSK" secondAttribute="height" multiplier="1:1" id="Gaq-r2-xY5"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PXL-Ac-bYs">
-                                <rect key="frame" x="47" y="250" width="187.5" height="187"/>
+                                <rect key="frame" x="47" y="250" width="187.5" height="187.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QVi-J3-gCN">
-                                        <rect key="frame" x="48" y="60" width="90.5" height="34"/>
+                                        <rect key="frame" x="48.5" y="59.5" width="90.5" height="34"/>
                                         <fontDescription key="fontDescription" name="CourierNewPSMT" family="Courier New" pointSize="30"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="m5x-2L-9Ru">
-                                        <rect key="frame" x="10" y="94" width="167.5" height="23"/>
+                                        <rect key="frame" x="10" y="93.5" width="167.5" height="23"/>
                                         <fontDescription key="fontDescription" name="CourierNewPSMT" family="Courier New" pointSize="20"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view hidden="YES" userInteractionEnabled="NO" alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0z8-ZB-yLw" customClass="TriangleView" customModule="ColorMixer" customModuleProvider="target">
-                                        <rect key="frame" x="76" y="33" width="34" height="17"/>
+                                        <rect key="frame" x="76.5" y="32.5" width="34" height="17"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="0z8-ZB-yLw" secondAttribute="height" multiplier="2:1" id="SrL-YM-Ygr"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3wZ-SF-3br">
-                                        <rect key="frame" x="71" y="113" width="45.5" height="17"/>
+                                        <rect key="frame" x="71" y="112.5" width="45.5" height="17"/>
                                         <fontDescription key="fontDescription" name="CourierNewPSMT" family="Courier New" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -283,11 +280,11 @@
                                     <outletCollection property="gestureRecognizers" destination="Oxd-Bv-ouO" appends="YES" id="0ta-gL-0b1"/>
                                 </connections>
                             </view>
-                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SRI-he-0jv">
+                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SRI-he-0jv" userLabel="LeftView">
                                 <rect key="frame" x="-70" y="20" width="100" height="647"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uyX-fP-1nO">
-                                        <rect key="frame" x="70" y="293" width="30" height="60"/>
+                                        <rect key="frame" x="70" y="293.5" width="30" height="60"/>
                                         <subviews>
                                             <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="15g-pg-IRc" customClass="TriangleView" customModule="ColorMixer" customModuleProvider="target">
                                                 <rect key="frame" x="4" y="7.5" width="22.5" height="45"/>
@@ -349,7 +346,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h8A-Y1-qcE" customClass="LandingLoadView" customModule="ColorMixer" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>
@@ -386,9 +383,9 @@
                             <constraint firstAttribute="trailing" secondItem="He5-0h-pwh" secondAttribute="centerX" constant="60" id="Z45-bs-t1y"/>
                             <constraint firstItem="h8A-Y1-qcE" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="abk-Nx-F0c"/>
                             <constraint firstItem="yJf-8M-pch" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" id="c62-cy-w2z"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="h8A-Y1-qcE" secondAttribute="bottom" id="dBk-LV-k0d"/>
+                            <constraint firstAttribute="bottom" secondItem="h8A-Y1-qcE" secondAttribute="bottom" id="dBk-LV-k0d"/>
                             <constraint firstItem="FKj-Fk-sqL" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="40" id="dHw-nD-OYq"/>
-                            <constraint firstItem="h8A-Y1-qcE" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="dh1-zb-UKm"/>
+                            <constraint firstItem="h8A-Y1-qcE" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="dh1-zb-UKm"/>
                             <constraint firstItem="bEU-6B-s9r" firstAttribute="trailing" secondItem="wON-v5-uqq" secondAttribute="trailing" id="f6Q-SA-uJo"/>
                             <constraint firstItem="PXL-Ac-bYs" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.5" id="fCK-QA-MV9"/>
                             <constraint firstItem="egy-Sb-LgQ" firstAttribute="centerY" secondItem="He5-0h-pwh" secondAttribute="centerY" id="i23-iQ-ZBC"/>


### PR DESCRIPTION
The pseudo loading view is pinned to the safeArea top and bottom which although nice does make the transition a little awkward.

I updated the top and bottom constraints to point to the superview vs the safe area. The transition looks much smoother now.